### PR TITLE
Fix new changes sync

### DIFF
--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -345,7 +345,7 @@ class SyncProjectTask(Task):
                 query = 'type:pr repo:%s' % project.name
                 if project.updated:
                     # Allow 4 seconds for request time, etc.
-                    query += ' created:%s' % ((project.updated - datetime.timedelta(seconds=4)).astimezone().replace(microsecond=0).isoformat(),)
+                    query += ' created:>%s' % ((project.updated - datetime.timedelta(seconds=4)).replace(microsecond=0).isoformat(),)
                 else:
                     query += ' state:open'
                 queries.append(query)


### PR DESCRIPTION
The query was missing the `>` operator, causing no new changes to be
retrieved.

Also, the date is already in UTC and including the timezone information
causes offsets.

Close #4