### PR TITLE
Ignore the virtualenv directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ doc/build
 AUTHORS
 ChangeLog
 build
+/venv


### PR DESCRIPTION
I usually use `venv` for the directory name :)