### PR TITLE
Default to username when we don't know the user's name

### DIFF
--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -251,7 +251,7 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
                 if comment.draft:
                     message = comment.message
                 else:
-                    message = [('comment-name', comment.author.name),
+                    message = [('comment-name', comment.author.name or comment.author.username),
                                ('comment', u': '+comment.message)]
                 comment_list.append((comment.key, message))
                 comment_lists[key] = comment_list
@@ -269,7 +269,7 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
                 if comment.draft:
                     message = comment.message
                 else:
-                    message = [('comment-name', comment.author.name),
+                    message = [('comment-name', comment.author.name or comment.author.username),
                                ('comment', u': '+comment.message)]
                 comment_list.append((comment.key, message))
                 comment_lists[key] = comment_list


### PR DESCRIPTION
There may be legitimate cases for the user to not have its name set. It
could be that it's unset in github or that sync didn't happen yet.
In this case, default to the username.

Fixes #9