### PR TITLE
There can be only one vote per user per commit

### DIFF
--- a/hubtty/alembic/versions/f3ceef330b1b_remove_approval_duplicates.py
+++ b/hubtty/alembic/versions/f3ceef330b1b_remove_approval_duplicates.py
@@ -1,0 +1,24 @@
+"""Remove approval duplicates
+
+Revision ID: f3ceef330b1b
+Revises: 9ab0f566d94b
+Create Date: 2021-03-05 09:50:46.558386
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f3ceef330b1b'
+down_revision = '9ab0f566d94b'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    connection = op.get_bind()
+    connection.execute('delete from approval where key not in (select max(key) from approval group by change_key,account_key,sha)')
+
+    op.create_index(op.f('ix_approval'), "approval", ["change_key", "account_key", "sha"])
+
+def downgrade():
+    pass

--- a/hubtty/db.py
+++ b/hubtty/db.py
@@ -1036,6 +1036,13 @@ class DatabaseSession(object):
         except sqlalchemy.orm.exc.NoResultFound:
             return None
 
+    def getApproval(self, change, account, sha):
+        try:
+            return self.session().query(Approval).filter_by(
+                change_key=change.key, account_key=account.key, sha=sha).one()
+        except sqlalchemy.orm.exc.NoResultFound:
+            return None
+
     def getHeld(self):
         return self.session().query(Change).filter_by(held=True).all()
 

--- a/hubtty/sync.py
+++ b/hubtty/sync.py
@@ -936,8 +936,12 @@ class SyncChangeTask(Task):
                 if review_status:
                     # TODO(mandre)
                     # - Rename approval.category to approval.status
-                    change.createApproval(account, review_status, remote_review.get('commit_id'))
-                    self.log.info("Created new approval for %s from %s commit %s.", change.change_id, account.username, remote_review.get('commit_id'))
+                    approval = session.getApproval(change, account, remote_review.get('commit_id'))
+                    if approval:
+                        approval.category = review_status
+                    else:
+                        change.createApproval(account, review_status, remote_review.get('commit_id'))
+                        self.log.info("Created new approval for %s from %s commit %s.", change.change_id, account.username, remote_review.get('commit_id'))
 
             # Inline comments
             for remote_comment in remote_pr_comments:


### PR DESCRIPTION
Re-use previously created approval record when syncing changes. This
prevents the UI from showing a tick in different approval categories at
the same time, for example `Changes Requested` and `Approved`, and stops
the explosion of records in the approval table.