### PR TITLE
Implement review key

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -339,8 +339,7 @@ Reviewkeys
 Reviewkeys are hotkeys that perform immediate reviews within the
 change screen.  Any pending comments or review messages will be
 attached to the review; otherwise an empty review message will be
-left.  The approvals list is exhaustive, so if you specify an empty
-list, Hubtty will submit a review that clears any previous approvals.
+left.
 Reviewkeys appear in the help text for the change screen.
 
 **reviewkeys**
@@ -350,40 +349,39 @@ Reviewkeys appear in the help text for the change screen.
   **key**
     This key to which this review action should be bound.
 
-  **approvals**
-    A list of approvals to include when this reviewkey is activated.
-    Each element of the list should include both a category and a
-    value.
-
-    **category**
-      The name of the review label for this approval.
-
-    **value**
-      The value for this approval.
+  **approval**
+    The status for the approval. Must be one of REQUEST_CHANGES, COMMENT, or
+    APPROVE.
 
   **message**
     Optional, it can be used to include a message during the review.
 
-  **submit**
-    Set this to `true` to instruct Github to submit the change when
-    this reviewkey is activated.
+  **description**
+    Optional, changes the description for the reviewkey in the help message.
 
-The following example includes a reviewkey that clears all labels,
-one that leaves a +1 "Code-Review" approval and another one that
-leaves 'recheck' on a review.
+  **draft**
+    Optional, keep the review as a draft and don't submit it right away.
+
+
+The following example includes a reviewkey that leaves a "/retest" message on
+a review, one that approves the PR, and another one that creates a draft message
+requesting for changes.
 
 .. code-block: yaml
 
-   reviewkeys:
-     - key: 'meta 0'
-       approvals: []
-     - key: 'meta 1'
-       approvals:
-         - category: 'Code-Review'
-           value: 1
-     - key: 'meta 2'
-       approvals: []
-       message: 'recheck'
+    reviewkeys:
+      - key: 'meta 0'
+        approval: 'COMMENT'
+        message: "/retest"
+      - key: 'meta 1'
+        approval: 'APPROVE'
+        message: ":shipit:"
+        description: 'Approve change'
+      - key: 'meta 2'
+        approval: 'REQUEST_CHANGES'
+        message: "Please add unit tests"
+        description: 'Request unit tests'
+        draft: True
 
 General Options
 +++++++++++++++

--- a/examples/reference-hubtty.yaml
+++ b/examples/reference-hubtty.yaml
@@ -219,30 +219,28 @@ dashboards:
     reverse: True
     key: "f5"
 
-# Reviewkeys are hotkeys that perform immediate reviews within the
-# change screen.  Any pending comments or review messages will be
-# attached to the review; otherwise an empty review will be left.  The
-# approvals list is exhaustive, so if you specify an empty list,
-# Hubtty will submit a review that clears any previous approvals.  To
-# submit the change with the review, include 'submit: True' with the
-# reviewkey.  Reviewkeys appear in the help text for the change
-# screen.
+# Reviewkeys are hotkeys that perform immediate reviews within the change
+# screen.  Any pending comments or review messages will be attached to the
+# review; otherwise an empty review will be left.
+# Approval must be one of REQUEST_CHANGES, COMMENT, or APPROVE.
+# To keep the review as a draft and not submit it right away, include 'draft:
+# True' with the reviewkey.  Reviewkeys appear in the help text for the change
+# screen. Use the 'description' parameter to change the help message for the
+# reviewkey.
 # reviewkeys:
 #   - key: 'meta 0'
-#     approvals: []
+#     approval: 'COMMENT'
+#     message: "/lgtm\n/approve"
+#     description: 'Comment with /lgtm and /approve'
 #   - key: 'meta 1'
-#     approvals:
-#       - category: 'Code-Review'
-#         value: 1
+#     approval: 'APPROVE'
+#     message: ":shipit:"
+#     description: 'Approve change'
 #   - key: 'meta 2'
-#     approvals:
-#       - category: 'Code-Review'
-#         value: 2
-#   - key: 'meta 3'
-#     approvals:
-#       - category: 'Code-Review'
-#         value: 2
-#     submit: True
+#     approval: 'REQUEST_CHANGES'
+#     message: "Please add unit tests"
+#     description: 'Request unit tests'
+#     draft: True
 
 # 'size-column' is a set of customize parameters for the 'Size' column
 # on your dashboard.

--- a/hubtty/config.py
+++ b/hubtty/config.py
@@ -89,11 +89,10 @@ class ConfigSchema(object):
 
     dashboards = [dashboard]
 
-    reviewkey_approval = {v.Required('category'): str,
-                          v.Required('value'): int}
-
-    reviewkey = {v.Required('approvals'): [reviewkey_approval],
+    reviewkey = {v.Required('approval'): v.Any('REQUEST_CHANGES', 'COMMENT', 'APPROVE'),
                  v.Optional('message'): str,
+                 v.Optional('description'): str,
+                 v.Optional('draft'): bool,
                  'submit': bool,
                  v.Required('key'): str}
 

--- a/hubtty/view/diff.py
+++ b/hubtty/view/diff.py
@@ -175,7 +175,12 @@ class BaseDiffView(urwid.WidgetWrap, mywid.Searchable):
         commands = self.getCommands()
         ret = [(c[0], key(c[0]), c[1]) for c in commands]
         for k in self.app.config.reviewkeys.values():
-            action = ', '.join(['{category}:{value}'.format(**a) for a in k['approvals']])
+            if k.get('description'):
+                action = k['description']
+            else:
+                action = k['approval']
+                if k.get('message'):
+                    action = action + ": " + k.get('message')
             ret.append(('', keymap.formatKey(k['key']), action))
         return ret
 


### PR DESCRIPTION
Compared to gertty's implementation:
- only one approval, and it must be one of REQUEST_CHANGES, COMMENT, or APPROVE
- add `draft` parameter to not upload review immediately
- add `description` parameter shows in help message
